### PR TITLE
remove ignore-missing-imports

### DIFF
--- a/{{cookiecutter.directory_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.directory_name}}/.pre-commit-config.yaml
@@ -61,9 +61,7 @@ repos:
           --explicit-package-bases,
           --strict,
           --python-version=3.12,
-          --show-error-codes,
-          --allow-untyped-decorators,
-          --ignore-missing-imports
+          --show-error-codes
         ]
 
       # Bandit for security scanning


### PR DESCRIPTION
This PR removes several mypy configuration flags from the pre-commit configuration, specifically removing --allow-untyped-decorators and --ignore-missing-imports while keeping --show-error-codes.

Key Changes:

Stricter type checking by removing permissive mypy flags
Eliminates suppression of missing import type hints
Removes allowance for untyped decorators