### PR TITLE
BAI-305 Fix FastApiLoggingMiddleware fully buffering streaming responses

### DIFF
--- a/{{cookiecutter.directory_name}}/tests/mcp_servers/middleware/test_fastapi_logging_middleware.py
+++ b/{{cookiecutter.directory_name}}/tests/mcp_servers/middleware/test_fastapi_logging_middleware.py
@@ -1,0 +1,93 @@
+from typing import AsyncIterator, List, cast
+
+from starlette.requests import Request
+from starlette.responses import Response, StreamingResponse
+
+from {{cookiecutter.project_slug}}.mcp_servers.middleware.fastapi_logging_middleware import (
+    FastApiLoggingMiddleware,
+)
+
+
+def _make_get_request(path: str = "/stream") -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+        "client": ("test", 123),
+    }
+    return Request(scope)
+
+
+async def test_streaming_response_is_not_fully_buffered_before_dispatch_returns() -> (
+    None
+):
+    """
+    Regression test for a bug where FastApiLoggingMiddleware.dispatch() eagerly
+    drained the entire body_iterator of a StreamingResponse (e.g. SSE / LLM token
+    streams) into memory before returning. That fully defeats streaming: the client
+    would receive nothing until the whole response had been produced and buffered,
+    then get it all at once.
+
+    The fix only peeks at the first chunk (needed for the log line) and lazily
+    rechains the remainder, so dispatch() must not pull more than one item from the
+    generator before it returns, and the rest of the stream must still be available
+    to the client afterward via the rechained iterator.
+    """
+    pulled_items: List[str] = []
+
+    async def event_stream() -> AsyncIterator[str]:
+        for i in range(5):
+            item = f"event-{i}\n"
+            pulled_items.append(item)
+            yield item
+
+    streaming_response = StreamingResponse(
+        event_stream(), media_type="text/event-stream"
+    )
+
+    async def call_next(_request: Request) -> Response:
+        return streaming_response
+
+    middleware = FastApiLoggingMiddleware(app=None)  # type: ignore[arg-type]
+
+    result = await middleware.dispatch(_make_get_request(), call_next)
+
+    # dispatch() must only have pulled the first chunk (needed for the log line)
+    # rather than eagerly draining the whole generator into memory.
+    assert pulled_items == [
+        "event-0\n"
+    ], f"dispatch() pulled more than the first chunk: {pulled_items!r}"
+
+    # The rest of the stream must still be reachable via the rechained iterator.
+    result_stream = cast(StreamingResponse, result)
+    remaining = [section async for section in result_stream.body_iterator]
+    assert remaining == [f"event-{i}\n" for i in range(5)]
+    assert pulled_items == [f"event-{i}\n" for i in range(5)]
+
+
+async def test_streaming_response_with_empty_body_iterator_logs_no_body() -> None:
+    """
+    An empty stream should not raise and dispatch() should leave the rechained
+    iterator empty for the client.
+    """
+
+    async def empty_stream() -> AsyncIterator[str]:
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    streaming_response = StreamingResponse(
+        empty_stream(), media_type="text/event-stream"
+    )
+
+    async def call_next(_request: Request) -> Response:
+        return streaming_response
+
+    middleware = FastApiLoggingMiddleware(app=None)  # type: ignore[arg-type]
+
+    result = await middleware.dispatch(_make_get_request(), call_next)
+
+    result_stream = cast(StreamingResponse, result)
+    remaining = [section async for section in result_stream.body_iterator]
+    assert remaining == []

--- a/{{cookiecutter.directory_name}}/{{cookiecutter.project_slug}}/mcp_servers/middleware/fastapi_logging_middleware.py
+++ b/{{cookiecutter.directory_name}}/{{cookiecutter.project_slug}}/mcp_servers/middleware/fastapi_logging_middleware.py
@@ -1,11 +1,10 @@
 import logging
 import time
-from typing import override, Callable, Awaitable, cast
+from typing import override, AsyncIterator, Callable, Awaitable, cast
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
-from starlette.concurrency import iterate_in_threadpool
 
 logger = logging.getLogger(__name__)
 
@@ -49,13 +48,30 @@ class FastApiLoggingMiddleware(BaseHTTPMiddleware):
         # if response is StreamingResponse, we need to read the body
         if "body_iterator" in response.__dict__:
             response1: StreamingResponse = cast(StreamingResponse, response)
-            res_body: list[str | bytes | memoryview] = [
-                section async for section in response1.body_iterator
-            ]
-            response1.body_iterator = iterate_in_threadpool(iter(res_body))
-            if len(res_body) > 0:
+            # Only peek at the first chunk (needed for the log line below) instead of
+            # eagerly draining the whole body_iterator into memory. Draining the full
+            # stream here would buffer the entire response before dispatch() returns,
+            # defeating streaming entirely (e.g. SSE/LLM token streams would stall
+            # until fully generated, then be released to the client all at once).
+            original_iterator = response1.body_iterator.__aiter__()
+            try:
+                first_chunk: str | bytes | memoryview | None = (
+                    await original_iterator.__anext__()
+                )
+            except StopAsyncIteration:
+                first_chunk = None
+
+            async def _rechain() -> AsyncIterator[str | bytes | memoryview]:
+                if first_chunk is not None:
+                    yield first_chunk
+                async for section in original_iterator:
+                    yield section
+
+            response1.body_iterator = _rechain()
+
+            if first_chunk is not None:
                 # Turn response body object to string
-                res_body_ = res_body[0]
+                res_body_ = first_chunk
                 res_body_text = (
                     res_body_.decode()
                     if isinstance(res_body_, bytes)


### PR DESCRIPTION
## Summary

`FastApiLoggingMiddleware.dispatch()` (in `{{cookiecutter.directory_name}}/{{cookiecutter.project_slug}}/mcp_servers/middleware/fastapi_logging_middleware.py`) eagerly drained **every** `StreamingResponse`'s `body_iterator` into a `list` via `[section async for section in response1.body_iterator]` before `dispatch()` could return. There was no SSE-vs-non-SSE branching, so this applied equally to `text/event-stream` responses (e.g. an LLM token stream or MCP server-sent events).

That full drain buffers the entire response body in memory and blocks `dispatch()` from returning until the *whole* stream has been produced — the client then receives everything at once instead of incrementally. This is the classic "FastAPI `StreamingResponse` not streaming" bug, and since this is a cookiecutter template, every service generated from it inherited the bug.

Only `res_body[0]` (the first chunk) was ever actually used, for the debug/error log line — draining the rest was pure waste with a serious side effect.

## Fix

- `dispatch()` now calls `.__aiter__()` on `body_iterator` and pulls only the **first** chunk via `.__anext__()` (needed for the existing log line).
- The rest of the stream is lazily rechained behind an async generator (`_rechain`) that yields the peeked first chunk, then delegates to the original iterator — so nothing beyond the first chunk is pulled before `dispatch()` returns, and the client still receives the stream incrementally.
- Removed the now-unused `iterate_in_threadpool` import; added `AsyncIterator` to the `typing` import.
- All existing logging/decoding behavior for both the streaming and non-streaming branches is preserved unchanged.

## Risk eliminated

Client stalls on any `StreamingResponse` (most importantly SSE/token streams) plus full in-memory buffering of the entire response body, for every project generated from this template.

## Verification

This repo has no root-level cookiecutter-generation test harness, so I generated a sample project directly (`cookiecutter --no-input . directory_name=sample_mcp_service`) and ran its actual verification path against the rendered files:

- `docker compose build dev` — builds cleanly with the change.
- `pytest tests` inside the `dev` container — **4/4 passed**, including the existing end-to-end GraphQL test and the MCP math-server test (no regressions), plus 2 new tests for this middleware.
- Confirmed the new regression test is a real regression test: swapped back in the original buggy `dispatch()` body and reran — the test failed as expected (it observed all 5 generator items pulled instead of 1), then re-confirmed green after restoring the fix.
- `ruff check` — all checks passed on both the fixed source file and the new test file.
- `mypy --explicit-package-bases --strict --python-version=3.12 --show-error-codes` (matching this repo's `.pre-commit-config.yaml` mypy args) — no issues on either file.

## Testing

- Added `{{cookiecutter.directory_name}}/tests/mcp_servers/middleware/test_fastapi_logging_middleware.py`:
  - `test_streaming_response_is_not_fully_buffered_before_dispatch_returns`: drives `dispatch()` directly with a tracked async generator (SSE media type) and asserts only the first item is pulled during `dispatch()` itself, then that the remaining items are still available afterward via the rechained iterator.
  - `test_streaming_response_with_empty_body_iterator_logs_no_body`: covers the empty-stream edge case (no `StopAsyncIteration` leaking, rechained iterator yields nothing).

Ref: BAI-305